### PR TITLE
time_entry field check added

### DIFF
--- a/lib/issues_controller_patch.rb
+++ b/lib/issues_controller_patch.rb
@@ -17,11 +17,11 @@ module RedmineSpentTimeRequired
         def update_with_check_spent_time
           allowed_statuses = Setting.plugin_redmine_spent_time_required['statuses'].scan(/\d+/)
           current_status = params[:issue][:status_id]
-          if ((params[:time_entry][:hours] == "") && (allowed_statuses.member?(current_status.to_s)))
-            flash[:error] = "Spent time required"
-            find_issue
-            update_issue_from_params
-            render(:action => 'edit') and return
+	  if params[:time_entry] != nil and ((params[:time_entry][:hours] == "") && (allowed_statuses.member?(current_status.to_s)))
+      		flash[:error] = "Spent time required"
+                find_issue
+                update_issue_from_params
+                render(:action => 'edit') and return
           else
             update_without_check_spent_time
           end


### PR DESCRIPTION
In case of time_entry field not exists, post requests from rest api fails. This check fixes it.